### PR TITLE
Remove final trailing comma. Test.

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func quickCheckJSON(data []byte) error {
 }
 
 func cleanTrailingCommas(data []byte) ([]byte, error) {
-	re, err := regexp.Compile(`(?ms),(\s*[}\]])`)
+	re, err := regexp.Compile(`,(\s*([}\]]|$))`)
 	if err != nil {
 		return nil, err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -34,6 +34,11 @@ func TestCleanTrailingCommas(t *testing.T) {
 				"foo": 1
 			}`,
 		},
+		{
+			name:   "final trailing comma",
+			input:  `{"foo": "bar"},`,
+			output: `{"foo": "bar"}`,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
This program would fail and quit if you fed it json with a final comma, like `{"foo": "bar"},`. I changed the matching expression to catch this.

I did not find `(?ms)` to be necessary. According to [the re2 syntax](https://github.com/google/re2/wiki/Syntax), `\s` matches `\n` anyway.